### PR TITLE
zigmod- build pcre from source instead of dynamic linking against system

### DIFF
--- a/zig.mod
+++ b/zig.mod
@@ -3,10 +3,5 @@ name: libpcre
 main: src/main.zig
 license: MIT
 description: Zig bindings to libpcre
-vcpkg: true
 dependencies:
-  - src: system_lib pcre
-    only_os: windows
-
-  - src: system_lib libpcre
-    except_os: windows
+  - src: git https://github.com/nektro/pcre-8.45

--- a/zigmod.lock
+++ b/zigmod.lock
@@ -1,1 +1,2 @@
 2
+git https://github.com/nektro/pcre-8.45 commit-faaca71dc3d6f8053e5e642b4cbceb038a476fb9


### PR DESCRIPTION
```
[meg@nixos:~/Downloads/libpcre.zig]$ zig build test
Test [1/5] test "compiles"... [default] (warn): pcre_compile (at 1): missing )

All 5 tests passed.
```