### PR TITLE
add build.zig.zon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 ![Build status](https://github.com/kivikakk/libpcre.zig/workflows/build/badge.svg)
 
-To build, add to your `build.zig`:
+To use via the zig package manager:
+
+```sh
+$ zig fetch --save https://github.com/kivikakk/libpcre.zig/archive/<commit hash>.tar.gz
+```
+
+Then add the following to `build.zig` (system `pcre` will be linked against automatically):
+
+```zig
+const pcre_pkg = b.dependency("libpcre.zig", .{ .optimize = optimize, .target = target });
+const pcre_mod = pcre_pkg.module("libpcre");
+exe.root_module.addImport("pcre", pcre_mod);
+```
+
+To use as a vendored library, add the following to your `build.zig`:
 
 ```zig
 const linkPcre = @import("vendor/libpcre.zig/build.zig").linkPcre;

--- a/build.zig
+++ b/build.zig
@@ -6,12 +6,12 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
 
     _ = b.addModule("libpcre", .{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
     });
 
     const lib = b.addStaticLibrary(.{
         .name = "libpcre.zig",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build) !void {
 
     const main_tests = b.addTest(.{
         .name = "main_tests",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .optimize = optimize,
         .target = target,
     });

--- a/build.zig
+++ b/build.zig
@@ -5,9 +5,12 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    _ = b.addModule("libpcre", .{
+    const mod = b.addModule("libpcre", .{
         .root_source_file = b.path("src/main.zig"),
+        .optimize = optimize,
+        .target = target,
     });
+    try linkPcre(b, mod);
 
     const lib = b.addStaticLibrary(.{
         .name = "libpcre.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,14 @@
+.{
+    .name = "libpcre.zig",
+    .version = "0.1.0",
+    .dependencies = .{},
+    .minimum_zig_version = "0.12.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "LICENSE",
+        "README.md",
+    },
+}
+


### PR DESCRIPTION
close #13
 - add build.zig.zon itself so repo can be used via `zig fetch --save`
 - turns out just linking the module to system pcre seems to work on the parent modules that depend on libpcre.zig (testing things on my own project, this libpcre.zig commit https://github.com/kivikakk/libpcre.zig/commit/fb5dd02337da7c82d5427c76c6154e1dabe4b7b6 builds locally on https://github.com/lun-4/awtfdb/commit/bd9aea1ba1e3250fb6d9561450d48a2983a46ce7, without requiring the linkSystemLibrary on awtfdb's side).
 - update readme