### PR TITLE
use a source build of libpcre

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -28,6 +28,17 @@ jobs:
       - run: brew install pcre
       - run: zig build
       - run: zig build test
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.12.0
+      - run: zig build -Dtarget=x86_64-windows-msvc
+      - run: zig build -Dtarget=x86_64-windows-msvc test
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![Build status](https://github.com/kivikakk/libpcre.zig/workflows/build/badge.svg)
 
-To use via the zig package manager:
+Use via the zig package manager (Zig v0.12+):
 
 ```sh
 $ zig fetch --save https://github.com/kivikakk/libpcre.zig/archive/<commit hash>.tar.gz
 ```
 
-Then add the following to `build.zig` (system `pcre` will be linked against automatically):
+Then add the following to `build.zig` (a source build of `pcre` will be linked against automatically):
 
 ```zig
 const pcre_pkg = b.dependency("libpcre.zig", .{ .optimize = optimize, .target = target });
@@ -16,18 +16,15 @@ const pcre_mod = pcre_pkg.module("libpcre");
 exe.root_module.addImport("pcre", pcre_mod);
 ```
 
-To use as a vendored library, add the following to your `build.zig`:
+To link against the system `libpcre`, add the `system_library` build option like this:
 
-```zig
-const linkPcre = @import("vendor/libpcre.zig/build.zig").linkPcre;
-try linkPcre(exe);
-exe.addPackagePath("libpcre", "vendor/libpcre.zig/src/main.zig");
-```
-
-Supported operating systems:
-
+Note, only the following systems support this mode:
 * Linux: `apt install pkg-config libpcre3-dev`
 * macOS: `brew install pkg-config pcre`
 * ~~Windows: install [vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows), `vcpkg integrate install`, `vcpkg install pcre --triplet x64-windows-static`~~
 
   Zig doesn't have vcpkg integration any more. Suggestions welcome!
+
+```zig
+const pcre_pkg = b.dependency("libpcre.zig", .{ .optimize = optimize, .target = target, .system_library = "true" });
+```

--- a/build.zig
+++ b/build.zig
@@ -33,7 +33,6 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
         .target = target,
     });
-    main_tests.linkLibC();
     try linkPcre(b, &main_tests.root_module, libpcre, use_system);
 
     const main_tests_run = b.addRunArtifact(main_tests);

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
-    const use_system = b.option(bool, "system_library", "link against libcpre from the system instead of source build") orelse if (target.result.os.tag == .macos) true else false;
+    const use_system = b.option(bool, "system_library", "link against libpcre from the system instead of source build") orelse if (target.result.os.tag == .macos) true else false;
     const pcre_dep = b.dependency("pcre", .{
         .optimize = optimize,
         .target = target,

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
-    const use_system = b.option(bool, "system_library", "link against libcpre from the system instead of source build") orelse false;
+    const use_system = b.option(bool, "system_library", "link against libcpre from the system instead of source build") orelse if (target.result.os.tag == .macos) true else false;
     const pcre_dep = b.dependency("pcre", .{
         .optimize = optimize,
         .target = target,

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
-    const use_system = b.option(bool, "system_library", "link against libpcre from the system instead of source build") orelse if (target.result.os.tag == .macos) true else false;
+    const use_system = b.option(bool, "system_library", "link against libpcre from the system instead of source build") orelse false;
     const pcre_dep = b.dependency("pcre", .{
         .optimize = optimize,
         .target = target,

--- a/build.zig
+++ b/build.zig
@@ -4,13 +4,19 @@ const builtin = @import("builtin");
 pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const use_system = b.option(bool, "system_library", "link against libcpre from the system instead of source build") orelse false;
+    const pcre_dep = b.dependency("pcre", .{
+        .optimize = optimize,
+        .target = target,
+    });
+    const libpcre = pcre_dep.artifact("pcre");
 
     const mod = b.addModule("libpcre", .{
         .root_source_file = b.path("src/main.zig"),
         .optimize = optimize,
         .target = target,
     });
-    try linkPcre(b, mod);
+    try linkPcre(b, mod, libpcre, use_system);
 
     const lib = b.addStaticLibrary(.{
         .name = "libpcre.zig",
@@ -18,7 +24,7 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     });
-    try linkPcre(b, &lib.root_module);
+    try linkPcre(b, &lib.root_module, libpcre, use_system);
     b.installArtifact(lib);
 
     const main_tests = b.addTest(.{
@@ -28,7 +34,7 @@ pub fn build(b: *std.Build) !void {
         .target = target,
     });
     main_tests.linkLibC();
-    try linkPcre(b, &main_tests.root_module);
+    try linkPcre(b, &main_tests.root_module, libpcre, use_system);
 
     const main_tests_run = b.addRunArtifact(main_tests);
     main_tests_run.step.dependOn(&main_tests.step);
@@ -37,18 +43,22 @@ pub fn build(b: *std.Build) !void {
     test_step.dependOn(&main_tests_run.step);
 }
 
-pub fn linkPcre(b: *std.Build, mod: *std.Build.Module) !void {
-    if (builtin.os.tag == .macos) {
-        // If `pkg-config libpcre` doesn't error, linkSystemLibrary("libpcre") will succeed.
-        // If it errors, try "pcre", as either it will hit a .pc by that name, or the fallthru
-        // `-lpcre` and standard includes will work.  (Or it's not installed.)
-        var code: u8 = undefined;
-        if (b.runAllowFail(&[_][]const u8{ "pkg-config", "libpcre" }, &code, .Inherit)) |_| {
-            mod.linkSystemLibrary("libpcre", .{});
-        } else |_| {
+pub fn linkPcre(b: *std.Build, mod: *std.Build.Module, libpcre: *std.Build.Step.Compile, use_system: bool) !void {
+    if (use_system) {
+        if (builtin.os.tag == .macos) {
+            // If `pkg-config libpcre` doesn't error, linkSystemLibrary("libpcre") will succeed.
+            // If it errors, try "pcre", as either it will hit a .pc by that name, or the fallthru
+            // `-lpcre` and standard includes will work.  (Or it's not installed.)
+            var code: u8 = undefined;
+            if (b.runAllowFail(&[_][]const u8{ "pkg-config", "libpcre" }, &code, .Inherit)) |_| {
+                mod.linkSystemLibrary("libpcre", .{});
+            } else |_| {
+                mod.linkSystemLibrary("pcre", .{});
+            }
+        } else {
             mod.linkSystemLibrary("pcre", .{});
         }
     } else {
-        mod.linkSystemLibrary("pcre", .{});
+        mod.linkLibrary(libpcre);
     }
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .pcre = .{
-            .url = "https://github.com/lun-4/pcre-8.45/archive/3c444040e8d025f6d6c6234e79f57f9d2ae37c5c.tar.gz",
-            .hash = "12205fec8827123a6019a6a34e7fc81345c424bf6a0df0ff57cb4909c0d57295ca75",
+            .url = "https://github.com/lun-4/pcre-8.45/archive/999bbb603e2d4b05acfbdd82df638eb6664a95c7.tar.gz",
+            .hash = "1220e7e5cb6837d9b0bc9b11f99d7a0660ea89490c41adcfede311196d9dc7e14066",
         },
     },
     .minimum_zig_version = "0.12.0",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .pcre = .{
-            .url = "https://github.com/lun-4/pcre-8.45/archive/109486bcddf726c124a6a69018ef986760ed98e2.tar.gz",
-            .hash = "12202a7fcc591f606904ae4e9ccd753fac03352cadea0bc1a5852678bafd7f1a78d0",
+            .url = "https://github.com/lun-4/pcre-8.45/archive/3c444040e8d025f6d6c6234e79f57f9d2ae37c5c.tar.gz",
+            .hash = "12205fec8827123a6019a6a34e7fc81345c424bf6a0df0ff57cb4909c0d57295ca75",
         },
     },
     .minimum_zig_version = "0.12.0",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,12 @@
 .{
     .name = "libpcre.zig",
     .version = "0.1.0",
-    .dependencies = .{},
+    .dependencies = .{
+        .pcre = .{
+            .url = "https://github.com/lun-4/pcre-8.45/archive/109486bcddf726c124a6a69018ef986760ed98e2.tar.gz",
+            .hash = "12202a7fcc591f606904ae4e9ccd753fac03352cadea0bc1a5852678bafd7f1a78d0",
+        },
+    },
     .minimum_zig_version = "0.12.0",
     .paths = .{
         "build.zig",
@@ -11,4 +16,3 @@
         "README.md",
     },
 }
-


### PR DESCRIPTION
removes the need to link against system libpcre

exposed pcre-8.45 as zigpkg which was used for the zigmod version of this library: https://github.com/nektro/pcre-8.45/pull/2 unknown if it'll be merged so libpcre.zig would depend on my fork of it

~~drawback is that macos won't compile with source build, it'll still use system libpcre by default such that nothing breaks~~ fixed

(this update should be carried out to koino post-merge such that koino doesn't depend on my fork of libpcre.zig, so I didn't open a PR for that yet)