### PR TITLE
workflows: build on 0.12 and 0.13.

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -5,31 +5,17 @@ on:
   pull_request:
 
 jobs:
-  test-linux:
-    runs-on: ubuntu-latest
+  tests:
+    strategy:
+      matrix:
+        zig-version: ["0.12.0", "0.13.0"]
+        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
-      - run: zig build
-      - run: zig build test
-  test-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@2a9625d550eefc3a9b1a43d342ad655f563f8241
-        with:
-          version: 0.12.0
-      - run: zig build
-      - run: zig build test
-  test-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: 0.12.0
+          version: ${{ matrix.zig-version }}
       - run: zig build
       - run: zig build test
   lint:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .pcre = .{
-            .url = "https://github.com/lun-4/pcre-8.45/archive/999bbb603e2d4b05acfbdd82df638eb6664a95c7.tar.gz",
-            .hash = "1220e7e5cb6837d9b0bc9b11f99d7a0660ea89490c41adcfede311196d9dc7e14066",
+            .url = "https://github.com/kivikakk/pcre-8.45/archive/812524706afd3a333c1fb31100e046f167740ac3.tar.gz",
+            .hash = "1220ac1f2dc0def06527baacecdacf3daae723bf0b439356ee5db6868ca255412b59",
         },
     },
     .minimum_zig_version = "0.12.0",


### PR DESCRIPTION
Pending a pcre-8.45 build change. (Letting CI fail first before pushing the candidate fix.)