### PR TITLE
Source build of libpcre faults on darwin-arm64.

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       matrix:
         zig-version: ["0.12.0", "0.13.0"]
-        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        runs-on: ["ubuntu-latest", "macos-13", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: goto-bus-stop/setup-zig@2a9625d550eefc3a9b1a43d342ad655f563f8241
         with:
           version: ${{ matrix.zig-version }}
       - run: zig build

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .pcre = .{
-            .url = "https://github.com/kivikakk/pcre-8.45/archive/812524706afd3a333c1fb31100e046f167740ac3.tar.gz",
-            .hash = "1220ac1f2dc0def06527baacecdacf3daae723bf0b439356ee5db6868ca255412b59",
+            .url = "https://github.com/kivikakk/pcre-8.45/archive/6b7cf03e4896c240c4baba2d6497e4be3ee1e22c.tar.gz",
+            .hash = "12203da4b45a5553c5a5f444b58378562cb4bea00e896426d82bd3164bfce811c5ab",
         },
     },
     .minimum_zig_version = "0.12.0",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .pcre = .{
-            .url = "https://github.com/kivikakk/pcre-8.45/archive/6b7cf03e4896c240c4baba2d6497e4be3ee1e22c.tar.gz",
-            .hash = "12203da4b45a5553c5a5f444b58378562cb4bea00e896426d82bd3164bfce811c5ab",
+            .url = "https://github.com/kivikakk/pcre-8.45/archive/6a08aa250b3ca1deea5fbc5f696bb4e25ac2da90.tar.gz",
+            .hash = "1220d07bc993a0378d209d115c8937d32b625bb70d3ac9ef9975efb961670af389a3",
         },
     },
     .minimum_zig_version = "0.12.0",

--- a/src/main.zig
+++ b/src/main.zig
@@ -256,3 +256,12 @@ test "missing capture group at end of capture list" {
         null,
     }, captures);
 }
+
+test "what" {
+    const regex = try Regex.compile("(?:(\\\\.|[^|\r\n])*)", .{ .Utf8 = true });
+    defer regex.deinit();
+    const line =
+        " the void type can only have a single value (which is also voida) and " ++
+        " indicates the absence of a value. Functions that do not ret |\n";
+    try testing.expect((try regex.matches(line, .{ .Anchored = true })) != null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -258,10 +258,11 @@ test "missing capture group at end of capture list" {
 }
 
 test "what" {
-    const regex = try Regex.compile("(?:(\\\\.|[^|\r\n])*)", .{ .Utf8 = true });
+    const regex = try Regex.compile("(?:ab|.)*", .{});
     defer regex.deinit();
+
     const line =
-        " the void type can only have a single value (which is also voida) and " ++
-        " indicates the absence of a value. Functions that do not ret |\n";
-    try testing.expect((try regex.matches(line, .{ .Anchored = true })) != null);
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ++
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+    try testing.expect((try regex.matches(line, .{})) != null);
 }


### PR DESCRIPTION
Passes under 0.13.0 x86_64 under Rosetta. Fails (SIGSEGV) on 0.12.0 and Zig HEAD on arm64.

Maybe I will care about this. Worth checking if the same holds on Linux.