### PR TITLE
Upgrade to zig v0.14.0

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -8,7 +8,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        zig-version: ["0.12.0", "0.13.0"]
+        zig-version: ["0.14.0"]
         runs-on: ["ubuntu-latest", "macos-13", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -26,5 +26,5 @@ jobs:
           submodules: recursive
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.12.0
+          version: 0.14.0
       - run: zig fmt --check build.zig src/*.zig

--- a/build.zig
+++ b/build.zig
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     });
-    try linkPcre(b, &lib.root_module, libpcre, use_system);
+    try linkPcre(b, lib.root_module, libpcre, use_system);
     b.installArtifact(lib);
 
     const main_tests = b.addTest(.{
@@ -33,7 +33,7 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
         .target = target,
     });
-    try linkPcre(b, &main_tests.root_module, libpcre, use_system);
+    try linkPcre(b, main_tests.root_module, libpcre, use_system);
 
     const main_tests_run = b.addRunArtifact(main_tests);
     main_tests_run.step.dependOn(&main_tests.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "libpcre.zig",
+    .name = .libpcre_zig,
     .version = "0.1.0",
     .dependencies = .{
         .pcre = .{
@@ -7,7 +7,8 @@
             .hash = "1220d07bc993a0378d209d115c8937d32b625bb70d3ac9ef9975efb961670af389a3",
         },
     },
-    .minimum_zig_version = "0.12.0",
+    .fingerprint = 0xc2f976f309fad70e,
+    .minimum_zig_version = "0.14.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
Updates the build system for Zig 0.14.0, including github workflows. Raises the minimum Zig version up to 0.14.0.